### PR TITLE
don't use all scriptable contents as it will use regular signals too

### DIFF
--- a/libnymea-core/pushbuttondbusservice.h
+++ b/libnymea-core/pushbuttondbusservice.h
@@ -37,6 +37,7 @@ public:
 
     bool agentAvailable() const;
 
+public slots:
     Q_SCRIPTABLE void RegisterButtonAgent(const QDBusObjectPath &agentPath);
     Q_SCRIPTABLE void UnregisterButtonAgent();
 

--- a/libnymea/hardware/bluetoothlowenergy/bluetoothlowenergymanager.h
+++ b/libnymea/hardware/bluetoothlowenergy/bluetoothlowenergymanager.h
@@ -51,6 +51,7 @@ public:
     virtual BluetoothLowEnergyDevice *registerDevice(const QBluetoothDeviceInfo &deviceInfo, const QLowEnergyController::RemoteAddressType &addressType = QLowEnergyController::RandomAddress) = 0;
     virtual void unregisterDevice(BluetoothLowEnergyDevice *bluetoothDevice) = 0;
 
+public slots:
     Q_SCRIPTABLE void EnableBluetooth(bool enabled);
 };
 

--- a/libnymea/nymeadbusservice.cpp
+++ b/libnymea/nymeadbusservice.cpp
@@ -36,7 +36,7 @@ NymeaDBusService::NymeaDBusService(const QString &objectPath, QObject *parent) :
         finalObjectPath.append(part.at(0).toUpper());
         finalObjectPath.append(part.right(part.length() - 1));
     }
-    status = s_connection.registerObject(finalObjectPath, this, QDBusConnection::ExportScriptableContents);
+    status = s_connection.registerObject(finalObjectPath, this, QDBusConnection::ExportScriptableSlots);
     if (!status) {
         qCWarning(dcApplication()) << "Failed to register D-Bus object:" << finalObjectPath;
         return;


### PR DESCRIPTION
this looks like a bug in Qt to me tbh. To get around it, restrict things more