### PR TITLE
make the REST server optional and disabled by default

### DIFF
--- a/libnymea-core/nymeaconfiguration.cpp
+++ b/libnymea-core/nymeaconfiguration.cpp
@@ -114,6 +114,7 @@ NymeaConfiguration::NymeaConfiguration(QObject *parent) :
         insecureConfig.sslEnabled = false;
         insecureConfig.authenticationEnabled = false;
         insecureConfig.publicFolder = defaultWebserverPublicFolderPath();
+        insecureConfig.restServerEnabled = false;
         m_webServerConfigs[insecureConfig.id] = insecureConfig;
         storeWebServerConfig(insecureConfig);
 
@@ -124,6 +125,7 @@ NymeaConfiguration::NymeaConfiguration(QObject *parent) :
         secureConfig.sslEnabled = true;
         secureConfig.authenticationEnabled = false;
         secureConfig.publicFolder = defaultWebserverPublicFolderPath();
+        secureConfig.restServerEnabled = false;
         m_webServerConfigs[secureConfig.id] = secureConfig;
         storeWebServerConfig(secureConfig);
     }
@@ -269,6 +271,7 @@ void NymeaConfiguration::setWebServerConfiguration(const WebServerConfiguration 
     settings.beginGroup("WebServer");
     settings.beginGroup(config.id);
     settings.setValue("publicFolder", config.publicFolder);
+    settings.setValue("restServerEnabled", config.restServerEnabled);
     settings.endGroup();
     settings.endGroup();
 
@@ -479,6 +482,7 @@ void NymeaConfiguration::storeWebServerConfig(const WebServerConfiguration &conf
     settings.beginGroup("WebServer");
     settings.beginGroup(config.id);
     settings.setValue("publicFolder", config.publicFolder);
+    settings.setValue("restServerEnabled", config.restServerEnabled);
     settings.endGroup();
     settings.endGroup();
 }
@@ -495,6 +499,7 @@ WebServerConfiguration NymeaConfiguration::readWebServerConfig(const QString &id
     config.sslEnabled = settings.value("sslEnabled", true).toBool();
     config.authenticationEnabled = settings.value("authenticationEnabled", true).toBool();
     config.publicFolder = settings.value("publicFolder").toString();
+    config.restServerEnabled = settings.value("restServerEnabled", false).toBool();
     settings.endGroup();
     settings.endGroup();
     return config;

--- a/libnymea-core/nymeaconfiguration.h
+++ b/libnymea-core/nymeaconfiguration.h
@@ -53,6 +53,7 @@ class WebServerConfiguration: public ServerConfiguration
 {
 public:
     QString publicFolder;
+    bool restServerEnabled = false;
 };
 
 class NymeaConfiguration : public QObject

--- a/libnymea-core/rest/restserver.h
+++ b/libnymea-core/rest/restserver.h
@@ -48,8 +48,7 @@ public:
     void registerWebserver(WebServer *webServer);
 
 private:
-    WebServer *m_webserver;
-    QList<QUuid> m_clientList;
+    QHash<QUuid, WebServer*> m_clientList;
     QHash<QString, RestResource *> m_resources;
 
     QHash<QUuid, HttpReply *> m_asyncReplies;

--- a/tests/auto/restdeviceclasses/testrestdeviceclasses.cpp
+++ b/tests/auto/restdeviceclasses/testrestdeviceclasses.cpp
@@ -80,6 +80,7 @@ void TestRestDeviceClasses::initTestCase()
     config.address = QHostAddress("127.0.0.1");
     config.port = 3333;
     config.sslEnabled = true;
+    config.restServerEnabled = true;
     NymeaCore::instance()->configuration()->setWebServerConfiguration(config);
     qApp->processEvents();
 }

--- a/tests/auto/restdevices/testrestdevices.cpp
+++ b/tests/auto/restdevices/testrestdevices.cpp
@@ -89,6 +89,7 @@ void TestRestDevices::initTestCase()
     config.address = QHostAddress("127.0.0.1");
     config.port = 3333;
     config.sslEnabled = true;
+    config.restServerEnabled = true;
     NymeaCore::instance()->configuration()->setWebServerConfiguration(config);
     qApp->processEvents();
 }

--- a/tests/auto/restlogging/testrestlogging.cpp
+++ b/tests/auto/restlogging/testrestlogging.cpp
@@ -72,6 +72,7 @@ void TestRestLogging::initTestCase()
     config.address = QHostAddress("127.0.0.1");
     config.port = 3333;
     config.sslEnabled = true;
+    config.restServerEnabled = true;
     NymeaCore::instance()->configuration()->setWebServerConfiguration(config);
     qApp->processEvents();
 }

--- a/tests/auto/restplugins/testrestplugins.cpp
+++ b/tests/auto/restplugins/testrestplugins.cpp
@@ -73,6 +73,7 @@ void TestRestPlugins::initTestCase()
     config.address = QHostAddress("127.0.0.1");
     config.port = 3333;
     config.sslEnabled = true;
+    config.restServerEnabled = true;
     NymeaCore::instance()->configuration()->setWebServerConfiguration(config);
     qApp->processEvents();
 }

--- a/tests/auto/restrules/testrestrules.cpp
+++ b/tests/auto/restrules/testrestrules.cpp
@@ -94,6 +94,7 @@ void TestRestRules::initTestCase()
     config.address = QHostAddress("127.0.0.1");
     config.port = 3333;
     config.sslEnabled = true;
+    config.restServerEnabled = true;
     NymeaCore::instance()->configuration()->setWebServerConfiguration(config);
     qApp->processEvents();
 }

--- a/tests/auto/restvendors/testrestvendors.cpp
+++ b/tests/auto/restvendors/testrestvendors.cpp
@@ -68,6 +68,7 @@ void TestRestVendors::initTestCase()
     config.address = QHostAddress("127.0.0.1");
     config.port = 3333;
     config.sslEnabled = true;
+    config.restServerEnabled = true;
     NymeaCore::instance()->configuration()->setWebServerConfiguration(config);
     qApp->processEvents();
 }

--- a/tests/auto/webserver/testwebserver.cpp
+++ b/tests/auto/webserver/testwebserver.cpp
@@ -96,6 +96,7 @@ void TestWebserver::initTestCase()
     config.address = QHostAddress("127.0.0.1");
     config.port = 3333;
     config.sslEnabled = true;
+    config.restServerEnabled = true;
     NymeaCore::instance()->configuration()->setWebServerConfiguration(config);
 }
 


### PR DESCRIPTION
Also fixes an issue where the REST server would sometimes
try to send the reply to the wrong WebServer instance

Note that the configuration of REST is currently not exposed via the JSONRPC API and can only be configured by manually editing the configuration file. The reason for this is that unless we're not certain that we actually want to keep the REST server support at all, I'd not introduce an API change on JSONRPC for it.