### PR TITLE
add timeouts to each network request

### DIFF
--- a/libnymea-core/hardware/network/networkaccessmanagerimpl.h
+++ b/libnymea-core/hardware/network/networkaccessmanagerimpl.h
@@ -33,6 +33,7 @@
 #include <QNetworkReply>
 #include <QDebug>
 #include <QUrl>
+#include <QTimer>
 
 namespace nymeaserver {
 
@@ -68,6 +69,13 @@ private:
     bool m_enabled = false;
 
     QNetworkAccessManager *m_manager;
+    QHash<QNetworkReply*, QTimer*> m_timeoutTimers;
+
+    void hookupTimeoutTimer(QNetworkReply* reply);
+
+private slots:
+    void networkReplyFinished();
+    void networkTimeout();
 
 };
 


### PR DESCRIPTION
QNetworkAccessManager apparently doesn't have its own timeouts. This can lead to a memory leak if QNetworkReply never replies but a plugin keeps on polling and creating more and more of them.

This branch adds a timeout to each request and closes the connection down eventually.

This also fixes issues we've seen with the Philips Hue bridge where it stops responding eventually. Turns out such never ending network requests kept a connection to the bridge open waiting for its reply forever. Eventually the bridge stops responding altogether to when it runs out of buffer for new handles. Now, aborting those never ending requests the bridge doesn't seem to enter this state any more... It keeps on sometimes to time out, but recovers again after that.