### PR TITLE
remove rules which are left without any action after a device removal

### DIFF
--- a/libnymea-core/ruleengine.cpp
+++ b/libnymea-core/ruleengine.cpp
@@ -1160,6 +1160,14 @@ void RuleEngine::removeDeviceFromRule(const RuleId &id, const DeviceId &deviceId
     settings.remove("");
     settings.endGroup();
 
+    if (actions.isEmpty() && exitActions.isEmpty()) {
+        // The rule doesn't have any actions any more and is useless at this point... let's remove it altogether
+        qCDebug(dcRuleEngine()) << "Rule" << rule.name() << "(" + rule.id().toString() + ")" << "does not have any actions any more. Removing it.";
+        m_rules.take(id);
+        emit ruleRemoved(id);
+        return;
+    }
+
     Rule newRule;
     newRule.setId(id);
     newRule.setName(rule.name());


### PR DESCRIPTION
This may happen on device removal with RemovePolicyUpdate or if an auto device is removed by the system.