### PR TITLE
Refactor packet fragmentation

### DIFF
--- a/libnymea-core/bluetoothserver.h
+++ b/libnymea-core/bluetoothserver.h
@@ -34,13 +34,15 @@ class BluetoothServer : public TransportInterface
 {
     Q_OBJECT
 public:
-    explicit BluetoothServer(QObject *parent = 0);
+    explicit BluetoothServer(QObject *parent = nullptr);
     ~BluetoothServer();
 
     static bool hardwareAvailable();
 
     void sendData(const QUuid &clientId, const QByteArray &data) override;
     void sendData(const QList<QUuid> &clients, const QByteArray &data) override;
+
+    void terminateClientConnection(const QUuid &clientId) override;
 
 private:
     QBluetoothServer *m_server = nullptr;
@@ -49,7 +51,6 @@ private:
 
     // Client storage
     QHash<QUuid, QBluetoothSocket *> m_clientList;
-    QByteArray m_receiveBuffer;
 
 private slots:
     void onHostModeChanged(const QBluetoothLocalDevice::HostMode &mode);

--- a/libnymea-core/cloud/cloudtransport.h
+++ b/libnymea-core/cloud/cloudtransport.h
@@ -36,6 +36,8 @@ public:
     void sendData(const QUuid &clientId, const QByteArray &data) override;
     void sendData(const QList<QUuid> &clientIds, const QByteArray &data) override;
 
+    void terminateClientConnection(const QUuid &clientId) override;
+
     bool startServer() override;
     bool stopServer() override;
 
@@ -43,11 +45,13 @@ signals:
 
 public slots:
     void connectToCloud(const QString &token, const QString &nonce);
-    void remoteConnectionStateChanged(remoteproxyclient::RemoteProxyConnection::State state);
 
 private slots:
+    void remoteConnectionStateChanged(remoteproxyclient::RemoteProxyConnection::State state);
+    void transportConnected();
     void transportReady();
     void transportDataReady(const QByteArray &data);
+    void transportDisconnected();
 
 private:
     QUrl m_proxyUrl;

--- a/libnymea-core/jsonrpc/jsonrpcserver.h
+++ b/libnymea-core/jsonrpc/jsonrpcserver.h
@@ -79,6 +79,8 @@ private:
     void sendUnauthorizedResponse(TransportInterface *interface, const QUuid &clientId, int commandId, const QString &error);
     QVariantMap createWelcomeMessage(TransportInterface *interface) const;
 
+    void processJsonPacket(TransportInterface *interface, const QUuid &clientId, const QByteArray &data);
+
 private slots:
     void setup();
 
@@ -101,6 +103,7 @@ private:
     QHash<JsonReply *, TransportInterface *> m_asyncReplies;
 
     QHash<QUuid, TransportInterface*> m_clientTransports;
+    QHash<QUuid, QByteArray> m_clientBuffers;
     QHash<QUuid, bool> m_clientNotifications;
     QHash<int, QUuid> m_pushButtonTransactions;
 

--- a/libnymea-core/mocktcpserver.cpp
+++ b/libnymea-core/mocktcpserver.cpp
@@ -52,6 +52,12 @@ void MockTcpServer::sendData(const QList<QUuid> &clients, const QByteArray &data
     }
 }
 
+void MockTcpServer::terminateClientConnection(const QUuid &clientId)
+{
+    emit connectionTerminated(clientId);
+    emit clientDisconnected(clientId);
+}
+
 QList<MockTcpServer *> MockTcpServer::servers()
 {
     return s_allServers;

--- a/libnymea-core/mocktcpserver.h
+++ b/libnymea-core/mocktcpserver.h
@@ -35,17 +35,19 @@ class MockTcpServer : public TransportInterface
 {
     Q_OBJECT
 public:
-    explicit MockTcpServer(QObject *parent = 0);
-    ~MockTcpServer();
+    explicit MockTcpServer(QObject *parent = nullptr);
+    ~MockTcpServer() override;
 
     void sendData(const QUuid &clientId, const QByteArray &data) override;
     void sendData(const QList<QUuid> &clients, const QByteArray &data) override;
+    void terminateClientConnection(const QUuid &clientId) override;
 
 /************** Used for testing **************************/
     static QList<MockTcpServer*> servers();
     void injectData(const QUuid &clientId, const QByteArray &data);
 signals:
     void outgoingData(const QUuid &clientId, const QByteArray &data);
+    void connectionTerminated(const QUuid &clientId);
 /************** Used for testing **************************/
 
 public slots:

--- a/libnymea-core/tcpserver.h
+++ b/libnymea-core/tcpserver.h
@@ -65,7 +65,6 @@ private slots:
 private:
     bool m_sslEnabled = false;
     QSslConfiguration m_config;
-    QByteArray m_receiveBuffer;
 };
 
 class TcpServer : public TransportInterface
@@ -79,6 +78,8 @@ public:
 
     void sendData(const QUuid &clientId, const QByteArray &data) override;
     void sendData(const QList<QUuid> &clients, const QByteArray &data) override;
+
+    void terminateClientConnection(const QUuid &clientId) override;
 
 private:
     QTimer *m_timer;

--- a/libnymea-core/transportinterface.cpp
+++ b/libnymea-core/transportinterface.cpp
@@ -62,6 +62,11 @@
     Pure virtual method for sending \a data to \a clients over the corresponding \l{TransportInterface}.
 */
 
+/*! \fn void nymeaserver::TransportInterface::terminateClientConnection(const QUuid &clientId);
+    Pure virtual method for terminating \a clients connection. The JSON RPC server might call this when a
+    client violates the protocol. Transports should immediately abort the connection to the client.
+*/
+
 /*! \fn void nymeaserver::TransportInterface::dataAvailable(const QUuid &clientId, const QByteArray &data);
     This signal is emitted when valid \a data from the client with the given \a clientId are available.
 

--- a/libnymea-core/transportinterface.h
+++ b/libnymea-core/transportinterface.h
@@ -40,6 +40,8 @@ public:
     virtual void sendData(const QUuid &clientId, const QByteArray &data) = 0;
     virtual void sendData(const QList<QUuid> &clients, const QByteArray &data) = 0;
 
+    virtual void terminateClientConnection(const QUuid &clientId) = 0;
+
     void setConfiguration(const ServerConfiguration &config);
     ServerConfiguration configuration() const;
 

--- a/libnymea-core/websocketserver.cpp
+++ b/libnymea-core/websocketserver.cpp
@@ -109,6 +109,14 @@ void WebSocketServer::sendData(const QList<QUuid> &clients, const QByteArray &da
     }
 }
 
+void WebSocketServer::terminateClientConnection(const QUuid &clientId)
+{
+    QWebSocket *client = m_clientList.value(clientId);
+    if (client) {
+        client->abort();
+    }
+}
+
 QHash<QString, QString> WebSocketServer::createTxtRecord()
 {
     // Note: reversed order

--- a/libnymea-core/websocketserver.h
+++ b/libnymea-core/websocketserver.h
@@ -50,6 +50,8 @@ public:
     void sendData(const QUuid &clientId, const QByteArray &data) override;
     void sendData(const QList<QUuid> &clients, const QByteArray &data) override;
 
+    void terminateClientConnection(const QUuid &clientId) override;
+
 private:
     QWebSocketServer *m_server = nullptr;
     QHash<QUuid, QWebSocket *> m_clientList;

--- a/tests/auto/nymeatestbase.h
+++ b/tests/auto/nymeatestbase.h
@@ -101,7 +101,7 @@ class NymeaTestBase : public QObject
 {
     Q_OBJECT
 public:
-    explicit NymeaTestBase(QObject *parent = 0);
+    explicit NymeaTestBase(QObject *parent = nullptr);
 
 protected slots:
     void initTestCase();


### PR DESCRIPTION
- Move Json packet fragmentation into the JsonRpcServer.
  This way we only have to do it once.

- fixes a bug in TcpServer and BluetoothServer
  where multiple clients would corrupt each others buffer

- fixes a bug in CloudTransport where it would leak client
  sockets after a remote connection disconnect