### PR TITLE
Remove redundant "close" action from garagegate interface

### DIFF
--- a/libnymea/interfaces/garagegate.json
+++ b/libnymea/interfaces/garagegate.json
@@ -10,10 +10,5 @@
             "name": "intermediatePosition",
             "type": "bool"
         }
-    ],
-    "actions": [
-        {
-            "name": "stop"
-        }
     ]
 }


### PR DESCRIPTION
It will be inherited by "closable"