### PR TITLE
Drop deprecated api

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+nymea (0.12.0) UNRELEASED; urgency=medium
+
+ -- Michael Zanetti <michael.zanetti@guh.io>  Fri, 22 Mar 2019 00:49:04 +0100
+
 nymea (0.11.1) xenial; urgency=medium
 
   [ Simon Stürz ]

--- a/doc/jsonrpc-api.qdoc
+++ b/doc/jsonrpc-api.qdoc
@@ -149,9 +149,6 @@ See also: \l{Param}
         "String"
     ], 
     "name": "String", 
-    "o:criticalStateTypeId": "Uuid", 
-    "o:primaryActionTypeId": "Uuid", 
-    "o:primaryStateTypeId": "Uuid", 
     "paramTypes": [
         "$ref:ParamType"
     ], 
@@ -3432,9 +3429,6 @@ See also: \l{Tag}
                 "String"
             ], 
             "name": "String", 
-            "o:criticalStateTypeId": "Uuid", 
-            "o:primaryActionTypeId": "Uuid", 
-            "o:primaryStateTypeId": "Uuid", 
             "paramTypes": [
                 "$ref:ParamType"
             ], 

--- a/doc/jsonrpc-api.qdoc
+++ b/doc/jsonrpc-api.qdoc
@@ -134,13 +134,9 @@ See also: \l{Param}
     "actionTypes": [
         "$ref:ActionType"
     ], 
-    "basicTags": [
-        "$ref:BasicTag"
-    ], 
     "createMethods": [
         "$ref:CreateMethod"
     ], 
-    "deviceIcon": "$ref:DeviceIcon", 
     "discoveryParamTypes": [
         "$ref:ParamType"
     ], 
@@ -167,7 +163,7 @@ See also: \l{Param}
     "vendorId": "Uuid"
 }
 \endcode
-See also: \l{ActionType}, \l{CreateMethod}, \l{DeviceIcon}, \l{BasicTag}, \l{ParamType}, \l{SetupMethod}, \l{StateType}, \l{EventType}, \l{ParamType}
+See also: \l{ActionType}, \l{CreateMethod}, \l{ParamType}, \l{SetupMethod}, \l{StateType}, \l{EventType}, \l{ParamType}
 \section2 DeviceDescriptor
 \code
 {
@@ -204,47 +200,6 @@ See also: \l{ActionType}, \l{CreateMethod}, \l{DeviceIcon}, \l{BasicTag}, \l{Par
     "DeviceErrorDeviceIsChild", 
     "DeviceErrorPairingTransactionIdNotFound", 
     "DeviceErrorParameterNotWritable"
-]
-\endcode
-\section2 DeviceIcon
-\code
-[
-    "DeviceIconNone", 
-    "DeviceIconBed", 
-    "DeviceIconBlinds", 
-    "DeviceIconCeilingLamp", 
-    "DeviceIconCouch", 
-    "DeviceIconDeskLamp", 
-    "DeviceIconDesk", 
-    "DeviceIconHifi", 
-    "DeviceIconPower", 
-    "DeviceIconEnergy", 
-    "DeviceIconRadio", 
-    "DeviceIconSmartPhone", 
-    "DeviceIconSocket", 
-    "DeviceIconStandardLamp", 
-    "DeviceIconSun", 
-    "DeviceIconTablet", 
-    "DeviceIconThermometer", 
-    "DeviceIconTune", 
-    "DeviceIconTv", 
-    "DeviceIconBattery", 
-    "DeviceIconDishwasher", 
-    "DeviceIconWashingMachine", 
-    "DeviceIconLaundryDryer", 
-    "DeviceIconIrHeater", 
-    "DeviceIconRadiator", 
-    "DeviceIconSwitch", 
-    "DeviceIconMotionDetectors", 
-    "DeviceIconWeather", 
-    "DeviceIconTime", 
-    "DeviceIconLightBulb", 
-    "DeviceIconGateway", 
-    "DeviceIconMail", 
-    "DeviceIconNetwork", 
-    "DeviceIconCloud", 
-    "DeviceIconGarage", 
-    "DeviceIconRollerShutter"
 ]
 \endcode
 \section2 Event
@@ -3403,26 +3358,6 @@ See also: \l{Tag}
                 "$ref:ParamType"
             ]
         }, 
-        "BasicTag": [
-            "BasicTagService", 
-            "BasicTagDevice", 
-            "BasicTagSensor", 
-            "BasicTagActuator", 
-            "BasicTagLighting", 
-            "BasicTagEnergy", 
-            "BasicTagMultimedia", 
-            "BasicTagWeather", 
-            "BasicTagGateway", 
-            "BasicTagHeating", 
-            "BasicTagCooling", 
-            "BasicTagNotification", 
-            "BasicTagSecurity", 
-            "BasicTagTime", 
-            "BasicTagShading", 
-            "BasicTagAppliance", 
-            "BasicTagCamera", 
-            "BasicTagLock"
-        ], 
         "BasicType": [
             "Uuid", 
             "String", 
@@ -3482,13 +3417,9 @@ See also: \l{Tag}
             "actionTypes": [
                 "$ref:ActionType"
             ], 
-            "basicTags": [
-                "$ref:BasicTag"
-            ], 
             "createMethods": [
                 "$ref:CreateMethod"
             ], 
-            "deviceIcon": "$ref:DeviceIcon", 
             "discoveryParamTypes": [
                 "$ref:ParamType"
             ], 
@@ -3544,44 +3475,6 @@ See also: \l{Tag}
             "DeviceErrorDeviceIsChild", 
             "DeviceErrorPairingTransactionIdNotFound", 
             "DeviceErrorParameterNotWritable"
-        ], 
-        "DeviceIcon": [
-            "DeviceIconNone", 
-            "DeviceIconBed", 
-            "DeviceIconBlinds", 
-            "DeviceIconCeilingLamp", 
-            "DeviceIconCouch", 
-            "DeviceIconDeskLamp", 
-            "DeviceIconDesk", 
-            "DeviceIconHifi", 
-            "DeviceIconPower", 
-            "DeviceIconEnergy", 
-            "DeviceIconRadio", 
-            "DeviceIconSmartPhone", 
-            "DeviceIconSocket", 
-            "DeviceIconStandardLamp", 
-            "DeviceIconSun", 
-            "DeviceIconTablet", 
-            "DeviceIconThermometer", 
-            "DeviceIconTune", 
-            "DeviceIconTv", 
-            "DeviceIconBattery", 
-            "DeviceIconDishwasher", 
-            "DeviceIconWashingMachine", 
-            "DeviceIconLaundryDryer", 
-            "DeviceIconIrHeater", 
-            "DeviceIconRadiator", 
-            "DeviceIconSwitch", 
-            "DeviceIconMotionDetectors", 
-            "DeviceIconWeather", 
-            "DeviceIconTime", 
-            "DeviceIconLightBulb", 
-            "DeviceIconGateway", 
-            "DeviceIconMail", 
-            "DeviceIconNetwork", 
-            "DeviceIconCloud", 
-            "DeviceIconGarage", 
-            "DeviceIconRollerShutter"
         ], 
         "Event": {
             "deviceId": "Uuid", 

--- a/doc/jsonrpc-api.qdoc
+++ b/doc/jsonrpc-api.qdoc
@@ -230,8 +230,6 @@ See also: \l{ParamDescriptor}
     "id": "Uuid", 
     "index": "Int", 
     "name": "String", 
-    "o:graphRelevant": "Bool", 
-    "o:ruleRelevant": "Bool", 
     "paramTypes": [
         "$ref:ParamType"
     ]
@@ -580,13 +578,11 @@ See also: \l{StateEvaluator}, \l{StateDescriptor}, \l{StateOperator}
     "id": "Uuid", 
     "index": "Int", 
     "name": "String", 
-    "o:graphRelevant": "Bool", 
     "o:maxValue": "Variant", 
     "o:minValue": "Variant", 
     "o:possibleValues": [
         "Variant"
     ], 
-    "o:ruleRelevant": "Bool", 
     "o:unit": "$ref:Unit", 
     "type": "$ref:BasicType"
 }
@@ -3491,8 +3487,6 @@ See also: \l{Tag}
             "id": "Uuid", 
             "index": "Int", 
             "name": "String", 
-            "o:graphRelevant": "Bool", 
-            "o:ruleRelevant": "Bool", 
             "paramTypes": [
                 "$ref:ParamType"
             ]
@@ -3742,13 +3736,11 @@ See also: \l{Tag}
             "id": "Uuid", 
             "index": "Int", 
             "name": "String", 
-            "o:graphRelevant": "Bool", 
             "o:maxValue": "Variant", 
             "o:minValue": "Variant", 
             "o:possibleValues": [
                 "Variant"
             ], 
-            "o:ruleRelevant": "Bool", 
             "o:unit": "$ref:Unit", 
             "type": "$ref:BasicType"
         }, 

--- a/doc/jsonrpc-api.qdoc
+++ b/doc/jsonrpc-api.qdoc
@@ -30,29 +30,6 @@ See also: \l{Param}
 }
 \endcode
 See also: \l{ParamType}
-\section2 BasicTag
-\code
-[
-    "BasicTagService", 
-    "BasicTagDevice", 
-    "BasicTagSensor", 
-    "BasicTagActuator", 
-    "BasicTagLighting", 
-    "BasicTagEnergy", 
-    "BasicTagMultimedia", 
-    "BasicTagWeather", 
-    "BasicTagGateway", 
-    "BasicTagHeating", 
-    "BasicTagCooling", 
-    "BasicTagNotification", 
-    "BasicTagSecurity", 
-    "BasicTagTime", 
-    "BasicTagShading", 
-    "BasicTagAppliance", 
-    "BasicTagCamera", 
-    "BasicTagLock"
-]
-\endcode
 \section2 BasicType
 \code
 [

--- a/doc/plugin-json.qdoc
+++ b/doc/plugin-json.qdoc
@@ -192,9 +192,7 @@
                             "displayName": "The name of the device class (translatable)",
                             "o:createMethods": [ ],
                             "o:setupMethod": "SetupMethod",
-                            "o:deviceIcon": "Icon",
                             "o:interfaces": [ "interfacename" ],
-                            "o:basicTags": [ ],
                             "o:pairingInfo": "Information how to pair the device. (translatable)",
                             "o:criticalStateTypeId": "uuid",
                             "o:primaryStateTypeId": "uuid",
@@ -233,34 +231,9 @@
             \li \tt interfaces
             \li \b O
             \li array
-            \li A string list of \l{Interfaces for DeviceClasses}{interfaces} this plugin implements. Interfaces show you how types
-                of this DeviceClass \underline{must} look like.
+            \li A string list of \l{Interfaces for DeviceClasses}{interfaces} this plugin implements. Interfaces define states, events and actions to
+                provide more defined ways of creating device class. A plugin developer should always try to follow interface definitions if possible.
         \row
-            \li \tt basicTags
-            \li \b O
-            \li array
-            \li A string list of \l{DeviceClass::BasicTag}{BasicTags} for this device \unicode{0x2192} \l{DeviceClass::basicTags()}. A \l{DeviceClass} can have
-                multiple \l{DeviceClass::BasicTag}{BasicTags} which describe the basic category of the DeviceClass.
-                A \l{DeviceClass} should be eighter a Service or a Device, never both. See enum \l{DeviceClass::BasicTag} for more information.
-                The expected value for the \e basicTags parameters matches the enum name like this:
-
-                \tt {DeviceClass::BasicTagService} \unicode{0x2192} \tt {"basicTags": [ "Service" ]}
-
-                \tt {DeviceClass::BasicTagLighting} \unicode{0x2192} \tt {"basicTags": [ "Lighting" ]}
-
-                \tt ...
-        \row
-            \li \tt deviceIcon
-            \li \b O
-            \li string
-            \li Defines the icon for this \l{DeviceClass}. See enum \l{DeviceClass::DeviceIcon} for more information. The expected value for the \tt deviceIcon
-                parameters matches the enum name like this:
-
-                \tt {DeviceClass::DeviceIconBed} \unicode{0x2192} \tt {"deviceIcon": "Bed"}
-
-                \tt {DeviceClass::DeviceIconPower} \unicode{0x2192} \tt {"deviceIcon": "Power"}
-
-                \tt ...
         \row
             \li \tt createMethods
             \li \b O

--- a/doc/plugin-json.qdoc
+++ b/doc/plugin-json.qdoc
@@ -194,9 +194,6 @@
                             "o:setupMethod": "SetupMethod",
                             "o:interfaces": [ "interfacename" ],
                             "o:pairingInfo": "Information how to pair the device. (translatable)",
-                            "o:criticalStateTypeId": "uuid",
-                            "o:primaryStateTypeId": "uuid",
-                            "o:primaryActionTypeId": "uuid",
                             "o:discoveryParamTypes": [ ],
                             "o:paramTypes": [ ],
                             "o:stateTypes": [ ],
@@ -268,21 +265,6 @@
             \li The \l{DeviceClass::pairingInfo()}{pairingInfo} will inform the user how to pair the device \unicode{0x2192} \l{DeviceClass::setupMethod()}.
                 This parameter will only be used for \l{DeviceClass::SetupMethodDisplayPin}{DisplayPin} and \l{DeviceClass::SetupMethodEnterPin}{EnterPin}
                 and \l{DeviceClass::SetupMethodPushButton}{PushButton}. Example: "Please press the button on the device before continue."
-        \row
-            \li \tt criticalStateTypeId
-            \li \b O
-            \li string
-            \li Deprecated: please use \l{Interfaces for DeviceClasses}{interfaces} instead.
-        \row
-            \li \tt primaryStateTypeId
-            \li \b O
-            \li string
-            \li Deprecated: please use \l{Interfaces for DeviceClasses}{interfaces} instead.
-        \row
-            \li \tt primaryActionTypeId
-            \li \b O
-            \li string
-            \li Deprecated: please use \l{Interfaces for DeviceClasses}{interfaces} instead.
         \row
             \li \tt discoveryParamTypes
             \li \b O

--- a/doc/plugin-json.qdoc
+++ b/doc/plugin-json.qdoc
@@ -431,9 +431,6 @@ A \l{StateType} has following parameters:
                     "type": "DataType",
                     "defaultValue": "The state will be initialized with this value."
                     "o:cached": "bool",
-                    "o:ruleRelevant": "bool",
-                    "o:eventRuleRelevant": "bool",
-                    "o:graphRelevant": "bool",
                     "o:unit": "The unit of the state value.",
                     "o:minValue": "Numeric minimum value for this state.",
                     "o:maxValue": "Numeric maximum value for this state.",
@@ -492,23 +489,6 @@ A \l{StateType} has following parameters:
             \li Indicates if a state value should be cached over reboot of the server. The value will be initialized with the last known value.
                 By default all states get chached. If you want to disable that behaviour you can set this property to \tt{false}. In that case the
                 value will be initialized with the default value of the State.
-        \row
-            \li \tt ruleRelevant
-            \li \b O
-            \li bool
-            \li Since not all \l{State}{States} make sense for the user in a rule, with this flag can be specified if this state should be visible
-                in the rule engine for the user or not. This flag has no effect to the ruleengine mechanism and is only ment to filter out not
-                interesting \l{State}{States}. By default, every state is rule relevant.
-        \row
-            \li \tt eventRuleRelevant
-            \li \b O
-            \li bool
-            \li Deprecated: please use \l{Interfaces for DeviceClasses}{interfaces} instead.
-        \row
-            \li \tt graphRelevant
-            \li \b O
-            \li bool
-            \li Deprecated: please use \l{Interfaces for DeviceClasses}{interfaces} instead.
         \row
             \li \tt unit
             \li \b O
@@ -665,8 +645,6 @@ A \l{StateType} has following parameters:
                     "id": "uuid",
                     "name": "eventName",
                     "displayName": "Name of the event (translatable)",
-                    "o:ruleRelevant": "bool",
-                    "o:graphRelevant": "bool",
                     "o:paramTypes": [
                         ...
                     ]
@@ -700,18 +678,6 @@ A \l{StateType} has following parameters:
             \li A list of \l{ParamType}{ParamTypes} which define the parameters of this event \unicode{0x2192} \l{EventType::paramTypes()}.
 
                 \b{See also:} \l{The ParamType definition}"
-        \row
-            \li \tt ruleRelevant
-            \li \b O
-            \li bool
-            \li Since not all \l{Event}{Events} make sense for the user in a rule, with this flag can be specidied if this event should be visible in the rule engine
-                for the user or not. This flag has no effect to the ruleengine mechanism and is only ment to filter out not interesting \l{Event}{Events}. By default,
-                every event is rule relevant.
-        \row
-            \li \tt graphRelevant
-            \li \b O
-            \li bool
-            \li Deprecated: please use \l{Interfaces for DeviceClasses}{interfaces} instead.
     \endtable
 
 */

--- a/libnymea-core/jsonrpc/jsontypes.cpp
+++ b/libnymea-core/jsonrpc/jsontypes.cpp
@@ -276,9 +276,6 @@ void JsonTypes::init()
     s_deviceClass.insert("interfaces", QVariantList() << basicTypeToString(String));
     s_deviceClass.insert("setupMethod", setupMethodRef());
     s_deviceClass.insert("createMethods", QVariantList() << createMethodRef());
-    s_deviceClass.insert("o:criticalStateTypeId", basicTypeToString(Uuid));
-    s_deviceClass.insert("o:primaryStateTypeId", basicTypeToString(Uuid));
-    s_deviceClass.insert("o:primaryActionTypeId", basicTypeToString(Uuid));
     s_deviceClass.insert("stateTypes", QVariantList() << stateTypeRef());
     s_deviceClass.insert("eventTypes", QVariantList() << eventTypeRef());
     s_deviceClass.insert("actionTypes", QVariantList() << actionTypeRef());
@@ -795,15 +792,6 @@ QVariantMap JsonTypes::packDeviceClass(const DeviceClass &deviceClass, const QLo
     QVariantList discoveryParamTypes;
     foreach (const ParamType &paramType, deviceClass.discoveryParamTypes())
         discoveryParamTypes.append(packParamType(paramType, deviceClass.pluginId(), locale));
-
-    if (!deviceClass.criticalStateTypeId().isNull())
-        variant.insert("criticalStateTypeId", deviceClass.criticalStateTypeId().toString());
-
-    if (!deviceClass.primaryStateTypeId().isNull())
-        variant.insert("primaryStateTypeId", deviceClass.primaryStateTypeId().toString());
-
-    if (!deviceClass.primaryActionTypeId().isNull())
-        variant.insert("primaryActionTypeId", deviceClass.primaryActionTypeId().toString());
 
     variant.insert("paramTypes", paramTypes);
     variant.insert("discoveryParamTypes", discoveryParamTypes);

--- a/libnymea-core/jsonrpc/jsontypes.cpp
+++ b/libnymea-core/jsonrpc/jsontypes.cpp
@@ -70,8 +70,6 @@ bool JsonTypes::s_initialized = false;
 QString JsonTypes::s_lastError;
 
 QVariantList JsonTypes::s_basicType;
-QVariantList JsonTypes::s_basicTag;
-QVariantList JsonTypes::s_deviceIcon;
 QVariantList JsonTypes::s_stateOperator;
 QVariantList JsonTypes::s_valueOperator;
 QVariantList JsonTypes::s_inputType;
@@ -139,8 +137,6 @@ void JsonTypes::init()
     s_unit = enumToStrings(Types::staticMetaObject, "Unit");
     s_createMethod = enumToStrings(DeviceClass::staticMetaObject, "CreateMethod");
     s_setupMethod = enumToStrings(DeviceClass::staticMetaObject, "SetupMethod");
-    s_basicTag = enumToStrings(DeviceClass::staticMetaObject, "BasicTag");
-    s_deviceIcon = enumToStrings(DeviceClass::staticMetaObject, "DeviceIcon");
     s_removePolicy = enumToStrings(RuleEngine::staticMetaObject, "RemovePolicy");
     s_deviceError = enumToStrings(DeviceManager::staticMetaObject, "DeviceError");
     s_ruleError = enumToStrings(RuleEngine::staticMetaObject, "RuleError");
@@ -277,9 +273,7 @@ void JsonTypes::init()
     s_deviceClass.insert("pluginId", basicTypeToString(Uuid));
     s_deviceClass.insert("name", basicTypeToString(String));
     s_deviceClass.insert("displayName", basicTypeToString(String));
-    s_deviceClass.insert("deviceIcon", deviceIconRef());
     s_deviceClass.insert("interfaces", QVariantList() << basicTypeToString(String));
-    s_deviceClass.insert("basicTags", QVariantList() << basicTagRef());
     s_deviceClass.insert("setupMethod", setupMethodRef());
     s_deviceClass.insert("createMethods", QVariantList() << createMethodRef());
     s_deviceClass.insert("o:criticalStateTypeId", basicTypeToString(Uuid));
@@ -437,13 +431,11 @@ QVariantMap JsonTypes::allTypes()
 {
     QVariantMap allTypes;
     allTypes.insert("BasicType", basicType());
-    allTypes.insert("BasicTag", basicTag());
     allTypes.insert("ParamType", paramTypeDescription());
     allTypes.insert("InputType", inputType());
     allTypes.insert("Unit", unit());
     allTypes.insert("CreateMethod", createMethod());
     allTypes.insert("SetupMethod", setupMethod());
-    allTypes.insert("DeviceIcon", deviceIcon());
     allTypes.insert("ValueOperator", valueOperator());
     allTypes.insert("StateOperator", stateOperator());
     allTypes.insert("RemovePolicy", removePolicy());
@@ -782,12 +774,7 @@ QVariantMap JsonTypes::packDeviceClass(const DeviceClass &deviceClass, const QLo
     variant.insert("displayName", NymeaCore::instance()->deviceManager()->translator()->translate(deviceClass.pluginId(), deviceClass.displayName(), locale));
     variant.insert("vendorId", deviceClass.vendorId().toString());
     variant.insert("pluginId", deviceClass.pluginId().toString());
-    variant.insert("deviceIcon", s_deviceIcon.at(deviceClass.deviceIcon()));
     variant.insert("interfaces", deviceClass.interfaces());
-
-    QVariantList basicTags;
-    foreach (const DeviceClass::BasicTag &basicTag, deviceClass.basicTags())
-        basicTags.append(s_basicTag.at(basicTag));
 
     QVariantList stateTypes;
     foreach (const StateType &stateType, deviceClass.stateTypes())
@@ -818,7 +805,6 @@ QVariantMap JsonTypes::packDeviceClass(const DeviceClass &deviceClass, const QLo
     if (!deviceClass.primaryActionTypeId().isNull())
         variant.insert("primaryActionTypeId", deviceClass.primaryActionTypeId().toString());
 
-    variant.insert("basicTags", basicTags);
     variant.insert("paramTypes", paramTypes);
     variant.insert("discoveryParamTypes", discoveryParamTypes);
     variant.insert("stateTypes", stateTypes);
@@ -2119,18 +2105,6 @@ QPair<bool, QString> JsonTypes::validateVariant(const QVariant &templateVariant,
                 QPair<bool, QString> result = validateEnum(s_unit, variant);
                 if (!result.first) {
                     qCWarning(dcJsonRpc) << QString("Value %1 not allowed in %2").arg(variant.toString()).arg(unitRef());
-                    return result;
-                }
-            } else if (refName == basicTagRef()) {
-                QPair<bool, QString> result = validateEnum(s_basicTag, variant);
-                if (!result.first) {
-                    qCWarning(dcJsonRpc) << QString("Value %1 not allowed in %2").arg(variant.toString()).arg(basicTagRef());
-                    return result;
-                }
-            } else if (refName == deviceIconRef()) {
-                QPair<bool, QString> result = validateEnum(s_deviceIcon, variant);
-                if (!result.first) {
-                    qCWarning(dcJsonRpc) << QString("Value %1 not allowed in %2").arg(variant.toString()).arg(deviceIconRef());
                     return result;
                 }
             } else if (refName == repeatingModeRef()) {

--- a/libnymea-core/jsonrpc/jsontypes.cpp
+++ b/libnymea-core/jsonrpc/jsontypes.cpp
@@ -199,8 +199,6 @@ void JsonTypes::init()
     s_stateType.insert("index", basicTypeToString(Int));
     s_stateType.insert("defaultValue", basicTypeToString(Variant));
     s_stateType.insert("o:unit", unitRef());
-    s_stateType.insert("o:ruleRelevant", basicTypeToString(Bool));
-    s_stateType.insert("o:graphRelevant", basicTypeToString(Bool));
     s_stateType.insert("o:minValue", basicTypeToString(Variant));
     s_stateType.insert("o:maxValue", basicTypeToString(Variant));
     s_stateType.insert("o:possibleValues", QVariantList() << basicTypeToString(Variant));
@@ -229,8 +227,6 @@ void JsonTypes::init()
     s_eventType.insert("displayName", basicTypeToString(String));
     s_eventType.insert("index", basicTypeToString(Int));
     s_eventType.insert("paramTypes", QVariantList() << paramTypeRef());
-    s_eventType.insert("o:ruleRelevant", basicTypeToString(Bool));
-    s_eventType.insert("o:graphRelevant", basicTypeToString(Bool));
 
     // Event
     s_event.insert("eventTypeId", basicTypeToString(Uuid));
@@ -496,11 +492,6 @@ QVariantMap JsonTypes::packEventType(const EventType &eventType, const PluginId 
     variant.insert("name", eventType.name());
     variant.insert("displayName", NymeaCore::instance()->deviceManager()->translator()->translate(pluginId, eventType.displayName(), locale));
     variant.insert("index", eventType.index());
-    if (!eventType.ruleRelevant())
-        variant.insert("ruleRelevant", false);
-
-    if (eventType.graphRelevant())
-        variant.insert("graphRelevant", true);
 
     QVariantList paramTypes;
     foreach (const ParamType &paramType, eventType.paramTypes())
@@ -630,12 +621,6 @@ QVariantMap JsonTypes::packStateType(const StateType &stateType, const PluginId 
     variantMap.insert("index", stateType.index());
     variantMap.insert("type", basicTypeToString(stateType.type()));
     variantMap.insert("defaultValue", stateType.defaultValue());
-
-    if (!stateType.ruleRelevant())
-        variantMap.insert("ruleRelevant", false);
-
-    if (stateType.graphRelevant())
-        variantMap.insert("graphRelevant", true);
 
     if (stateType.maxValue().isValid())
         variantMap.insert("maxValue", stateType.maxValue());

--- a/libnymea-core/jsonrpc/jsontypes.h
+++ b/libnymea-core/jsonrpc/jsontypes.h
@@ -120,14 +120,12 @@ public:
     static QVariantMap allTypes();
 
     DECLARE_TYPE(basicType, "BasicType", JsonTypes, BasicType)
-    DECLARE_TYPE(basicTag, "BasicTag", DeviceClass, BasicTag)
     DECLARE_TYPE(stateOperator, "StateOperator", Types, StateOperator)
     DECLARE_TYPE(valueOperator, "ValueOperator", Types, ValueOperator)
     DECLARE_TYPE(inputType, "InputType", Types, InputType)
     DECLARE_TYPE(unit, "Unit", Types, Unit)
     DECLARE_TYPE(createMethod, "CreateMethod", DeviceClass, CreateMethod)
     DECLARE_TYPE(setupMethod, "SetupMethod", DeviceClass, SetupMethod)
-    DECLARE_TYPE(deviceIcon, "DeviceIcon", DeviceClass, DeviceIcon)
     DECLARE_TYPE(deviceError, "DeviceError", DeviceManager, DeviceError)
     DECLARE_TYPE(removePolicy, "RemovePolicy", RuleEngine, RemovePolicy)
     DECLARE_TYPE(ruleError, "RuleError", RuleEngine, RuleError)

--- a/libnymea/plugin/deviceplugin.cpp
+++ b/libnymea/plugin/deviceplugin.cpp
@@ -594,15 +594,6 @@ void DevicePlugin::loadMetaData()
             }
             deviceClass.setCreateMethods(createMethods);
 
-            // Read device icon
-            QPair<bool, DeviceClass::DeviceIcon> deviceIconVerification = loadAndVerifyDeviceIcon(deviceClassObject.value("deviceIcon").toString());
-            if (!deviceIconVerification.first) {
-                broken = true;
-                break;
-            } else {
-                deviceClass.setDeviceIcon(deviceIconVerification.second);
-            }
-
             // Read params
             QPair<bool, QList<ParamType> > paramTypesVerification = parseParamTypes(deviceClassObject.value("paramTypes").toArray());
             if (!paramTypesVerification.first) {
@@ -643,19 +634,6 @@ void DevicePlugin::loadMetaData()
 
             // Read pairing info
             deviceClass.setPairingInfo(deviceClassObject.value("pairingInfo").toString());
-
-            // Read basic tags
-            QList<DeviceClass::BasicTag> basicTags;
-            foreach (const QJsonValue &basicTagJson, deviceClassObject.value("basicTags").toArray()) {
-                QPair<bool, DeviceClass::BasicTag> basicTagVerification = loadAndVerifyBasicTag(basicTagJson.toString());
-                if (!basicTagVerification.first) {
-                    broken = true;
-                    break;
-                } else {
-                    basicTags.append(basicTagVerification.second);
-                }
-            }
-            deviceClass.setBasicTags(basicTags);
 
             QList<ActionType> actionTypes;
             QList<StateType> stateTypes;
@@ -1051,58 +1029,6 @@ QPair<bool, Types::InputType> DevicePlugin::loadAndVerifyInputType(const QString
     }
 
     return QPair<bool, Types::InputType>(true, (Types::InputType)enumValue);
-}
-
-QPair<bool, DeviceClass::BasicTag> DevicePlugin::loadAndVerifyBasicTag(const QString &basicTag) const
-{
-    if (basicTag.isEmpty())
-        return QPair<bool, DeviceClass::BasicTag>(true, DeviceClass::BasicTagDevice);
-
-    QMetaObject metaObject = DeviceClass::staticMetaObject;
-    int enumIndex = metaObject.indexOfEnumerator(QString("BasicTag").toLatin1().data());
-    QMetaEnum metaEnum = metaObject.enumerator(enumIndex);
-
-    int enumValue = -1;
-    for (int i = 0; i < metaEnum.keyCount(); i++) {
-        if (QString(metaEnum.valueToKey(metaEnum.value(i))) == QString("BasicTag" + basicTag)) {
-            enumValue = metaEnum.value(i);
-            break;
-        }
-    }
-
-    // inform the plugin developer about the error in the plugin json file
-    if (enumValue == -1) {
-        qCWarning(dcDeviceManager()) << QString("\"%1\" plugin:").arg(pluginName()).toLatin1().data() << QString("Invalid basicTag \"%1\" in json file.").arg(basicTag).toLatin1().data();
-        return QPair<bool, DeviceClass::BasicTag>(false, DeviceClass::BasicTagDevice);
-    }
-
-    return QPair<bool, DeviceClass::BasicTag>(true, (DeviceClass::BasicTag)enumValue);
-}
-
-QPair<bool, DeviceClass::DeviceIcon> DevicePlugin::loadAndVerifyDeviceIcon(const QString &deviceIcon) const
-{
-    if (deviceIcon.isEmpty())
-        return QPair<bool, DeviceClass::DeviceIcon>(true, DeviceClass::DeviceIconNone);
-
-    QMetaObject metaObject = DeviceClass::staticMetaObject;
-    int enumIndex = metaObject.indexOfEnumerator(QString("DeviceIcon").toLatin1().data());
-    QMetaEnum metaEnum = metaObject.enumerator(enumIndex);
-
-    int enumValue = -1;
-    for (int i = 0; i < metaEnum.keyCount(); i++) {
-        if (QString(metaEnum.valueToKey(metaEnum.value(i))) == QString("DeviceIcon" + deviceIcon)) {
-            enumValue = metaEnum.value(i);
-            break;
-        }
-    }
-
-    // inform the plugin developer about the error in the plugin json file
-    if (enumValue == -1) {
-        qCWarning(dcDeviceManager()) << QString("\"%1\" plugin:").arg(pluginName()).toLatin1().data() << QString("Invalid deviceIcon \"%1\" in json file.").arg(deviceIcon).toLatin1().data();
-        return QPair<bool, DeviceClass::DeviceIcon>(false, DeviceClass::DeviceIconNone);
-    }
-
-    return QPair<bool, DeviceClass::DeviceIcon>(true, (DeviceClass::DeviceIcon)enumValue);
 }
 
 Interfaces DevicePlugin::allInterfaces()

--- a/libnymea/plugin/deviceplugin.cpp
+++ b/libnymea/plugin/deviceplugin.cpp
@@ -833,41 +833,6 @@ void DevicePlugin::loadMetaData()
             }
             deviceClass.setEventTypes(eventTypes);
 
-            // Note: keep this after the actionType / stateType / eventType parsing
-            if (deviceClassObject.contains("criticalStateTypeId")) {
-                StateTypeId criticalStateTypeId = StateTypeId(deviceClassObject.value("criticalStateTypeId").toString());
-                if (!deviceClass.hasStateType(criticalStateTypeId)) {
-                    qCWarning(dcDeviceManager()) << "Skipping device class" << deviceClass.name() << ": the definend critical stateTypeId" << criticalStateTypeId.toString() << "does not match any StateType of this DeviceClass.";
-                    broken = true;
-                } else if (deviceClass.getStateType(criticalStateTypeId).type() != QVariant::Bool) {
-                    // Make sure the critical stateType is a bool state
-                    qCWarning(dcDeviceManager()) << "Skipping device class" << deviceClass.name() << ": the definend critical stateTypeId" << criticalStateTypeId.toString() << "is not a bool StateType.";
-                    broken = true;
-                } else {
-                    deviceClass.setCriticalStateTypeId(criticalStateTypeId);
-                }
-            }
-
-            if (deviceClassObject.contains("primaryStateTypeId")) {
-                StateTypeId primaryStateTypeId = StateTypeId(deviceClassObject.value("primaryStateTypeId").toString());
-                if (!deviceClass.hasStateType(primaryStateTypeId)) {
-                    qCWarning(dcDeviceManager()) << "Skipping device class" << deviceClass.name() << ": the definend primary stateTypeId" << primaryStateTypeId.toString() << "does not match any StateType of this DeviceClass.";
-                    broken = true;
-                } else {
-                    deviceClass.setPrimaryStateTypeId(primaryStateTypeId);
-                }
-            }
-
-            if (deviceClassObject.contains("primaryActionTypeId")) {
-                ActionTypeId primaryActionTypeId = ActionTypeId(deviceClassObject.value("primaryActionTypeId").toString());
-                if (!deviceClass.hasActionType(primaryActionTypeId)) {
-                    qCWarning(dcDeviceManager()) << "Skipping device class" << deviceClass.name() << ": the definend primary actionTypeId" << primaryActionTypeId.toString() << "does not match any ActionType of this DeviceClass.";
-                    broken = true;
-                } else {
-                    deviceClass.setPrimaryActionTypeId(primaryActionTypeId);
-                }
-            }
-
             // Read interfaces
             QStringList interfaces;
             foreach (const QJsonValue &value, deviceClassObject.value("interfaces").toArray()) {

--- a/libnymea/plugin/deviceplugin.cpp
+++ b/libnymea/plugin/deviceplugin.cpp
@@ -698,12 +698,6 @@ void DevicePlugin::loadMetaData()
                 if (st.contains("maxValue"))
                     stateType.setMaxValue(st.value("maxValue").toVariant());
 
-                if (st.contains("ruleRelevant"))
-                    stateType.setRuleRelevant(st.value("ruleRelevant").toBool());
-
-                if (st.contains("graphRelevant"))
-                    stateType.setGraphRelevant(st.value("graphRelevant").toBool());
-
                 if (st.contains("possibleValues")) {
                     QVariantList possibleValues;
                     foreach (const QJsonValue &possibleValueJson, st.value("possibleValues").toArray()) {
@@ -726,9 +720,6 @@ void DevicePlugin::loadMetaData()
 
                 // Events for state changed
                 EventType eventType(EventTypeId(stateType.id().toString()));
-                if (st.contains("eventRuleRelevant"))
-                    eventType.setRuleRelevant(st.value("eventRuleRelevant").toBool());
-
                 eventType.setName(st.value("name").toString());
                 eventType.setDisplayName(st.value("displayNameEvent").toString());
                 ParamType paramType(ParamTypeId(stateType.id().toString()), st.value("name").toString(), stateType.type());
@@ -816,11 +807,6 @@ void DevicePlugin::loadMetaData()
                 eventType.setName(et.value("name").toString());
                 eventType.setDisplayName(et.value("displayName").toString());
                 eventType.setIndex(index++);
-                if (et.contains("ruleRelevant"))
-                    eventType.setRuleRelevant(et.value("ruleRelevant").toBool());
-
-                if (et.contains("graphRelevant"))
-                    eventType.setGraphRelevant(et.value("graphRelevant").toBool());
 
                 QPair<bool, QList<ParamType> > paramVerification = parseParamTypes(et.value("paramTypes").toArray());
                 if (!paramVerification.first) {

--- a/libnymea/plugin/deviceplugin.h
+++ b/libnymea/plugin/deviceplugin.h
@@ -113,8 +113,6 @@ private:
     // load and verify enum values
     QPair<bool, Types::Unit> loadAndVerifyUnit(const QString &unitString) const;
     QPair<bool, Types::InputType> loadAndVerifyInputType(const QString &inputType) const;
-    QPair<bool, DeviceClass::BasicTag> loadAndVerifyBasicTag(const QString &basicTag) const;
-    QPair<bool, DeviceClass::DeviceIcon> loadAndVerifyDeviceIcon(const QString &deviceIcon) const;
 
     // FIXME: This is expensive because it will open all the files.
     // Once DeviceManager is in libnymea-core this should probably be there too.

--- a/libnymea/types/deviceclass.cpp
+++ b/libnymea/types/deviceclass.cpp
@@ -73,9 +73,6 @@ DeviceClass::DeviceClass(const PluginId &pluginId, const VendorId &vendorId, con
     m_id(id),
     m_vendorId(vendorId),
     m_pluginId(pluginId),
-    m_criticalStateTypeId(StateTypeId()),
-    m_primaryStateTypeId(StateTypeId()),
-    m_primaryActionTypeId(ActionTypeId()),
     m_createMethods(CreateMethodUser),
     m_setupMethod(SetupMethodJustAdd)
 {
@@ -128,43 +125,6 @@ QString DeviceClass::displayName() const
 void DeviceClass::setDisplayName(const QString &displayName)
 {
     m_displayName = displayName;
-}
-
-/*! Returns the critical \l{StateTypeId} of this \l{DeviceClass}.
- * A critical \l{State} describes the state which disables the whole device (i.e. connected, available or reachable). */
-StateTypeId DeviceClass::criticalStateTypeId() const
-{
-    return m_criticalStateTypeId;
-}
-
-/*! Set the \a criticalStateTypeId of this \l{DeviceClass}. */
-void DeviceClass::setCriticalStateTypeId(const StateTypeId &criticalStateTypeId)
-{
-    m_criticalStateTypeId = criticalStateTypeId;
-}
-
-/*! Returns the primary \l{StateTypeId} of this \l{DeviceClass}. */
-StateTypeId DeviceClass::primaryStateTypeId() const
-{
-    return m_primaryStateTypeId;
-}
-
-/*! Set the \a primaryStateTypeId of this \l{DeviceClass}. */
-void DeviceClass::setPrimaryStateTypeId(const StateTypeId &primaryStateTypeId)
-{
-    m_primaryStateTypeId = primaryStateTypeId;
-}
-
-/*! Returns the primary \l{ActionTypeId} of this \l{DeviceClass}. */
-ActionTypeId DeviceClass::primaryActionTypeId() const
-{
-    return m_primaryActionTypeId;
-}
-
-/*! Set the \a primaryActionTypeId of this \l{DeviceClass}. */
-void DeviceClass::setPrimaryActionTypeId(const ActionTypeId &primaryActionTypeId)
-{
-    m_primaryActionTypeId = primaryActionTypeId;
 }
 
 /*! Returns the statesTypes of this DeviceClass. \{Device}{Devices} created
@@ -344,9 +304,8 @@ bool DeviceClass::operator==(const DeviceClass &deviceClass) const
 QStringList DeviceClass::typeProperties()
 {
     return QStringList() << "id" << "name" << "displayName" << "createMethods" << "setupMethod"
-                         << "interfaces" << "pairingInfo" << "criticalStateTypeId"
-                         << "primaryStateTypeId" << "primaryActionTypeId" << "discoveryParamTypes"
-                         << "discoveryParamTypes" << "paramTypes" << "stateTypes" << "actionTypes" << "eventTypes";
+                         << "interfaces" << "pairingInfo" << "discoveryParamTypes" << "discoveryParamTypes"
+                         << "paramTypes" << "stateTypes" << "actionTypes" << "eventTypes";
 }
 
 /*! Returns a list of mandatory JSON properties a DeviceClass JSON definition must have. */

--- a/libnymea/types/deviceclass.cpp
+++ b/libnymea/types/deviceclass.cpp
@@ -62,103 +62,6 @@
         During the setup, a button has to be pushed in order to pair the \l{Device}.
 */
 
-/*! \enum DeviceClass::BasicTag
-
-    This enum type specifies the basic tags which describe the categories of the DeviceClass.
-    A DeviceClass can have multiple tags.
-
-    \value BasicTagService
-        The \l{DeviceClass} describes a service.
-    \value BasicTagDevice
-        The \l{DeviceClass} describes a real device.
-    \value BasicTagSensor
-        The \l{DeviceClass} describes a sensor. Any device which can measure or detect something is a sensor.
-    \value BasicTagActuator
-        The \l{DeviceClass} describes an actuator. Any device which can do something is an actuator.
-    \value BasicTagLighting
-        The \l{DeviceClass} describes a lighting device.
-    \value BasicTagEnergy
-        The \l{DeviceClass} describes an energy device.
-    \value BasicTagMultimedia
-        The \l{DeviceClass} describes a multimedia device/service.
-    \value BasicTagWeather
-        The \l{DeviceClass} describes a weather device/service.
-    \value BasicTagGateway
-        The \l{DeviceClass} describes a gateway device.
-    \value BasicTagHeating
-        The \l{DeviceClass} describes a heating device.
-    \value BasicTagCooling
-        The \l{DeviceClass} describes a cooling device.
-    \value BasicTagNotification
-        The \l{DeviceClass} describes a notification service.
-    \value BasicTagSecurity
-        The \l{DeviceClass} describes a security device/service.
-    \value BasicTagTime
-        The \l{DeviceClass} describes a time device/service.
-    \value BasicTagShading
-        The \l{DeviceClass} describes a shading device.
-    \value BasicTagAppliance
-        The \l{DeviceClass} describes an appliance.
-    \value BasicTagCamera
-        The \l{DeviceClass} describes a camera device.
-    \value BasicTagLock
-        The \l{DeviceClass} describes a lock device.
-
-*/
-
-/*! \enum DeviceClass::DeviceIcon
-
-    This enum type specifies the default device icon of the DeviceClass.
-    Each client should have an icon set containing this list of icon types.
-    If a client want's to offer special icons for a special DeviceClass or device type,
-    he can bring it's own icon for a special DeviceClassId. If there is no special icon
-    defined, he can fallback to the default icon.
-
-    \value DeviceIconNone
-    \value DeviceIconBed
-    \value DeviceIconBlinds
-    \value DeviceIconCeilingLamp
-    \value DeviceIconCouch
-    \value DeviceIconDeskLamp
-    \value DeviceIconDesk
-    \value DeviceIconHifi
-    \value DeviceIconPower
-    \value DeviceIconEnergy
-    \value DeviceIconRadio
-    \value DeviceIconSmartPhone
-    \value DeviceIconSocket
-    \value DeviceIconStandardLamp
-    \value DeviceIconSun
-    \value DeviceIconTablet
-    \value DeviceIconThermometer
-    \value DeviceIconTune
-    \value DeviceIconTv
-    \value DeviceIconBattery
-    \value DeviceIconDishwasher
-    \value DeviceIconWashingMachine
-    \value DeviceIconLaundryDryer
-    \value DeviceIconIrHeater
-    \value DeviceIconRadiator
-    \value DeviceIconSwitch
-    \value DeviceIconMotionDetectors
-    \value DeviceIconWeather
-    \value DeviceIconTime
-    \value DeviceIconLightBulb
-    \value DeviceIconGateway
-    \value DeviceIconMail
-    \value DeviceIconNetwork
-    \value DeviceIconCloud
-    \value DeviceIconGarage,
-    \value DeviceIconRollerShutter
-*/
-
-/*! \fn void DeviceClass::setBasicTags(const QList<BasicTag> &basicTags);
-    Set the list of \a basicTags of this DeviceClass.
-*/
-
-/*! \fn void DeviceClass::setDeviceIcon(const DeviceIcon &deviceIcon);
-    Set the \a deviceIcon of this DeviceClass.
-*/
 
 #include "deviceclass.h"
 
@@ -173,7 +76,6 @@ DeviceClass::DeviceClass(const PluginId &pluginId, const VendorId &vendorId, con
     m_criticalStateTypeId(StateTypeId()),
     m_primaryStateTypeId(StateTypeId()),
     m_primaryActionTypeId(ActionTypeId()),
-    m_deviceIcon(DeviceIconPower),
     m_createMethods(CreateMethodUser),
     m_setupMethod(SetupMethodJustAdd)
 {
@@ -263,39 +165,6 @@ ActionTypeId DeviceClass::primaryActionTypeId() const
 void DeviceClass::setPrimaryActionTypeId(const ActionTypeId &primaryActionTypeId)
 {
     m_primaryActionTypeId = primaryActionTypeId;
-}
-
-/*! Returns the default \l{DeviceIcon} of this \l{DeviceClass}. */
-DeviceClass::DeviceIcon DeviceClass::deviceIcon() const
-{
-    return m_deviceIcon;
-}
-
-/*! Set the \a deviceIcon of this \l{DeviceClass}.
-
-    \sa DeviceClass::DeviceIcon
-*/
-void DeviceClass::setDeviceIcon(const DeviceClass::DeviceIcon &deviceIcon)
-{
-    m_deviceIcon = deviceIcon;
-}
-
-/*! Returns the list of basicTags of this DeviceClass.
-
-    \sa DeviceClass::BasicTag
-*/
-QList<DeviceClass::BasicTag> DeviceClass::basicTags() const
-{
-    return m_basicTags;
-}
-
-/*! Set the list of \a basicTags of this DeviceClass.
-
-    \sa DeviceClass::BasicTag
-*/
-void DeviceClass::setBasicTags(const QList<DeviceClass::BasicTag> &basicTags)
-{
-    m_basicTags = basicTags;
 }
 
 /*! Returns the statesTypes of this DeviceClass. \{Device}{Devices} created
@@ -474,8 +343,8 @@ bool DeviceClass::operator==(const DeviceClass &deviceClass) const
 /*! Returns a list of all valid JSON properties a DeviceClass JSON definition can have. */
 QStringList DeviceClass::typeProperties()
 {
-    return QStringList() << "id" << "name" << "displayName" << "createMethods" << "setupMethod" << "deviceIcon"
-                         << "interfaces" << "basicTags" << "pairingInfo" << "criticalStateTypeId"
+    return QStringList() << "id" << "name" << "displayName" << "createMethods" << "setupMethod"
+                         << "interfaces" << "pairingInfo" << "criticalStateTypeId"
                          << "primaryStateTypeId" << "primaryActionTypeId" << "discoveryParamTypes"
                          << "discoveryParamTypes" << "paramTypes" << "stateTypes" << "actionTypes" << "eventTypes";
 }

--- a/libnymea/types/deviceclass.h
+++ b/libnymea/types/deviceclass.h
@@ -71,15 +71,6 @@ public:
     QString displayName() const;
     void setDisplayName(const QString &displayName);
 
-    StateTypeId criticalStateTypeId() const;
-    void setCriticalStateTypeId(const StateTypeId &criticalStateTypeId);
-
-    StateTypeId primaryStateTypeId() const;
-    void setPrimaryStateTypeId(const StateTypeId &primaryStateTypeId);
-
-    ActionTypeId primaryActionTypeId() const;
-    void setPrimaryActionTypeId(const ActionTypeId &primaryActionTypeId);
-
     StateTypes stateTypes() const;
     StateType getStateType(const StateTypeId &stateTypeId);
     void setStateTypes(const QList<StateType> &stateTypes);
@@ -122,9 +113,6 @@ private:
     PluginId m_pluginId;
     QString m_name;
     QString m_displayName;
-    StateTypeId m_criticalStateTypeId;
-    StateTypeId m_primaryStateTypeId;
-    ActionTypeId m_primaryActionTypeId;
     QList<StateType> m_stateTypes;
     QList<EventType> m_eventTypes;
     QList<ActionType> m_actionTypes;

--- a/libnymea/types/deviceclass.h
+++ b/libnymea/types/deviceclass.h
@@ -41,8 +41,7 @@ class LIBNYMEA_EXPORT DeviceClass
     Q_ENUMS(CreateMethod)
     Q_ENUMS(SetupMethod)
     Q_ENUMS(BasicTag)
-    Q_ENUMS(DeviceIcon)
-    Q_FLAGS(CreateMethods)
+    Q_ENUMS(CreateMethods)
 
 public:
     enum CreateMethod {
@@ -57,66 +56,6 @@ public:
         SetupMethodDisplayPin,
         SetupMethodEnterPin,
         SetupMethodPushButton
-    };
-
-    enum BasicTag {
-        BasicTagService,
-        BasicTagDevice,
-        BasicTagSensor,
-        BasicTagActuator,
-        BasicTagLighting,
-        BasicTagEnergy,
-        BasicTagMultimedia,
-        BasicTagWeather,
-        BasicTagGateway,
-        BasicTagHeating,
-        BasicTagCooling,
-        BasicTagNotification,
-        BasicTagSecurity,
-        BasicTagTime,
-        BasicTagShading,
-        BasicTagAppliance,
-        BasicTagCamera,
-        BasicTagLock
-    };
-
-    enum DeviceIcon {
-        DeviceIconNone,
-        DeviceIconBed,
-        DeviceIconBlinds,
-        DeviceIconCeilingLamp,
-        DeviceIconCouch,
-        DeviceIconDeskLamp,
-        DeviceIconDesk,
-        DeviceIconHifi,
-        DeviceIconPower,
-        DeviceIconEnergy,
-        DeviceIconRadio,
-        DeviceIconSmartPhone,
-        DeviceIconSocket,
-        DeviceIconStandardLamp,
-        DeviceIconSun,
-        DeviceIconTablet,
-        DeviceIconThermometer,
-        DeviceIconTune,
-        DeviceIconTv,
-        DeviceIconBattery,
-        DeviceIconDishwasher,
-        DeviceIconWashingMachine,
-        DeviceIconLaundryDryer,
-        DeviceIconIrHeater,
-        DeviceIconRadiator,
-        DeviceIconSwitch,
-        DeviceIconMotionDetectors,
-        DeviceIconWeather,
-        DeviceIconTime,
-        DeviceIconLightBulb,
-        DeviceIconGateway,
-        DeviceIconMail,
-        DeviceIconNetwork,
-        DeviceIconCloud,
-        DeviceIconGarage,
-        DeviceIconRollerShutter
     };
 
     DeviceClass(const PluginId &pluginId = PluginId(), const VendorId &vendorId = VendorId(), const DeviceClassId &id = DeviceClassId());
@@ -140,12 +79,6 @@ public:
 
     ActionTypeId primaryActionTypeId() const;
     void setPrimaryActionTypeId(const ActionTypeId &primaryActionTypeId);
-
-    DeviceIcon deviceIcon() const;
-    void setDeviceIcon(const DeviceIcon &deviceIcon);
-
-    QList<BasicTag> basicTags() const;
-    void setBasicTags(const QList<BasicTag> &basicTags);
 
     StateTypes stateTypes() const;
     StateType getStateType(const StateTypeId &stateTypeId);
@@ -192,8 +125,6 @@ private:
     StateTypeId m_criticalStateTypeId;
     StateTypeId m_primaryStateTypeId;
     ActionTypeId m_primaryActionTypeId;
-    DeviceIcon m_deviceIcon;
-    QList<BasicTag> m_basicTags;
     QList<StateType> m_stateTypes;
     QList<EventType> m_eventTypes;
     QList<ActionType> m_actionTypes;

--- a/libnymea/types/eventtype.cpp
+++ b/libnymea/types/eventtype.cpp
@@ -36,9 +36,7 @@
 /*! Constructs a EventType object with the given \a id. */
 EventType::EventType(const EventTypeId &id):
     m_id(id),
-    m_index(0),
-    m_ruleRelevant(true),
-    m_graphRelevant(false)
+    m_index(0)
 {
 
 }
@@ -100,30 +98,6 @@ void EventType::setParamTypes(const ParamTypes &paramTypes)
     m_paramTypes = paramTypes;
 }
 
-/*! Returns true if this EventType is relevant for the rule from a user perspective. */
-bool EventType::ruleRelevant() const
-{
-    return m_ruleRelevant;
-}
-
-/*! Sets this EventType relevant for the rule from a user perspective to \a ruleRelevant. */
-void EventType::setRuleRelevant(const bool &ruleRelevant)
-{
-    m_ruleRelevant = ruleRelevant;
-}
-
-/*! Returns true if this EventType is interesting to visualize the logs in a graph/chart from a user perspective. */
-bool EventType::graphRelevant() const
-{
-    return m_graphRelevant;
-}
-
-/*! Sets this EventType \a graphRelevant to inform the client application if this \l{EventType} is interesting to visualize the logs in a graph/chart. */
-void EventType::setGraphRelevant(const bool &graphRelevant)
-{
-    m_graphRelevant = graphRelevant;
-}
-
 /*! Returns true if this EventType has a valid id and name */
 bool EventType::isValid() const
 {
@@ -133,7 +107,7 @@ bool EventType::isValid() const
 /*! Returns a list of all valid JSON properties a EventType JSON definition can have. */
 QStringList EventType::typeProperties()
 {
-    return QStringList() << "id" << "name" << "displayName" << "paramTypes" << "ruleRelevant" << "graphRelevant";
+    return QStringList() << "id" << "name" << "displayName" << "paramTypes";
 }
 
 /*! Returns a list of mandatory JSON properties a EventType JSON definition must have. */

--- a/libnymea/types/eventtype.h
+++ b/libnymea/types/eventtype.h
@@ -49,12 +49,6 @@ public:
     ParamTypes paramTypes() const;
     void setParamTypes(const ParamTypes &paramTypes);
 
-    bool ruleRelevant() const;
-    void setRuleRelevant(const bool &ruleRelevant);
-
-    bool graphRelevant() const;
-    void setGraphRelevant(const bool &graphRelevant);
-
     bool isValid() const;
 
     static QStringList typeProperties();
@@ -66,8 +60,6 @@ private:
     QString m_displayName;
     int m_index;
     QList<ParamType> m_paramTypes;
-    bool m_ruleRelevant;
-    bool m_graphRelevant;
 };
 
 class EventTypes: public QList<EventType>

--- a/libnymea/types/statetype.cpp
+++ b/libnymea/types/statetype.cpp
@@ -160,30 +160,6 @@ void StateType::setUnit(const Types::Unit &unit)
     m_unit = unit;
 }
 
-/*! Returns true if this StateType is relevant for the rule from a user perspective. */
-bool StateType::ruleRelevant() const
-{
-    return m_ruleRelevant;
-}
-
-/*! Sets this StateType relevant for the rule from a user perspective to \a ruleRelevant. */
-void StateType::setRuleRelevant(const bool &ruleRelevant)
-{
-    m_ruleRelevant = ruleRelevant;
-}
-
-/*! Returns true if this StateType is interesting to visualize the logs in a graph/chart from a user perspective. */
-bool StateType::graphRelevant() const
-{
-    return m_graphRelevant;
-}
-
-/*! Sets this StateType \a graphRelevant to inform the client application if this \l{StateType} is interesting to visualize the logs in a graph/chart. */
-void StateType::setGraphRelevant(const bool &graphRelevant)
-{
-    m_graphRelevant = graphRelevant;
-}
-
 /*! Returns true if this StateType is to be cached. This means, the last state value will be stored to disk upon shutdown and restored on reboot. If this is false, states will be initialized with the default value on each boot. By default all states are cached by the system. */
 bool StateType::cached() const
 {
@@ -200,8 +176,8 @@ void StateType::setCached(bool cached)
 QStringList StateType::typeProperties()
 {
     return QStringList() << "id" << "name" << "displayName" << "displayNameEvent" << "type" << "defaultValue"
-                         << "cached" << "ruleRelevant" << "eventRuleRelevant" << "graphRelevant" << "unit"
-                         << "minValue" << "maxValue" << "possibleValues" << "writable" << "displayNameAction";
+                         << "cached" << "unit" << "minValue" << "maxValue" << "possibleValues" << "writable"
+                         << "displayNameAction";
 }
 
 /*! Returns a list of mandatory properties a DeviceClass definition must have. */

--- a/libnymea/types/statetype.h
+++ b/libnymea/types/statetype.h
@@ -64,12 +64,6 @@ public:
     Types::Unit unit() const;
     void setUnit(const Types::Unit &unit);
 
-    bool ruleRelevant() const;
-    void setRuleRelevant(const bool &ruleRelevant);
-
-    bool graphRelevant() const;
-    void setGraphRelevant(const bool &graphRelevant);
-
     bool cached() const;
     void setCached(bool cached);
 
@@ -87,8 +81,6 @@ private:
     QVariant m_maxValue;
     QVariantList m_possibleValues;
     Types::Unit m_unit = Types::UnitNone;
-    bool m_ruleRelevant = true;
-    bool m_graphRelevant = false;
     bool m_cached = true;
 };
 

--- a/nymea.pri
+++ b/nymea.pri
@@ -5,8 +5,8 @@ NYMEA_VERSION_STRING=$$system('dpkg-parsechangelog | sed -n -e "s/^Version: //p"
 NYMEA_PLUGINS_PATH=/usr/lib/$$system('dpkg-architecture -q DEB_HOST_MULTIARCH')/nymea/plugins/
 
 # define protocol versions
-JSON_PROTOCOL_VERSION_MAJOR=1
-JSON_PROTOCOL_VERSION_MINOR=15
+JSON_PROTOCOL_VERSION_MAJOR=2
+JSON_PROTOCOL_VERSION_MINOR=0
 REST_API_VERSION=1
 
 DEFINES += NYMEA_VERSION_STRING=\\\"$${NYMEA_VERSION_STRING}\\\" \

--- a/plugins/mock/devicepluginmock.json
+++ b/plugins/mock/devicepluginmock.json
@@ -72,7 +72,6 @@
                             "displayName": "Dummy int state",
                             "displayNameEvent": "Dummy int state changed",
                             "defaultValue": 10,
-                            "graphRelevant": true,
                             "type": "int"
                         },
                         {
@@ -128,8 +127,7 @@
                         {
                             "id": "45bf3752-0fc6-46b9-89fd-ffd878b5b22b",
                             "name": "mockEvent1",
-                            "displayName": "Mock Event 1",
-                            "graphRelevant": true
+                            "displayName": "Mock Event 1"
                         },
                         {
                             "id": "863d5920-b1cf-4eb9-88bd-8f7b8583b1cf",
@@ -224,7 +222,6 @@
                             "displayName": "Dummy int state",
                             "displayNameEvent": "Dummy int state changed",
                             "defaultValue": 10,
-                            "graphRelevant": true,
                             "type": "int"
                         },
                         {
@@ -328,8 +325,6 @@
                             "displayNameAction": "Set color",
                             "type": "QColor",
                             "defaultValue": "#000000",
-                            "ruleRelevant": false,
-                            "eventRuleRelevant": false,
                             "writable": true
                         },
                         {
@@ -341,7 +336,6 @@
                             "type": "int",
                             "unit": "Percentage",
                             "defaultValue": 0,
-                            "ruleRelevant": false,
                             "minValue": 0,
                             "maxValue": 100,
                             "writable": true
@@ -431,8 +425,6 @@
                             "displayNameAction": "Set color",
                             "type": "QColor",
                             "defaultValue": "#000000",
-                            "ruleRelevant": false,
-                            "eventRuleRelevant": false,
                             "writable": true
                         },
                         {
@@ -444,7 +436,6 @@
                             "type": "int",
                             "unit": "Percentage",
                             "defaultValue": 0,
-                            "ruleRelevant": false,
                             "minValue": 0,
                             "maxValue": 100,
                             "writable": true

--- a/plugins/mock/devicepluginmock.json
+++ b/plugins/mock/devicepluginmock.json
@@ -30,13 +30,7 @@
                     "id": "753f0d32-0468-4d08-82ed-1964aab03298",
                     "name": "mock",
                     "displayName": "Mock Device",
-                    "deviceIcon": "Tune",
                     "interfaces": ["system", "light", "gateway", "battery"],
-                    "basicTags": [
-                        "Device",
-                        "Actuator",
-                        "Gateway"
-                    ],
                     "createMethods": ["user", "discovery"],
                     "primaryActionTypeId": "defd3ed6-1a0d-400b-8879-a0202cf39935",
                     "primaryStateTypeId": "80baec19-54de-4948-ac46-31eabfaceb83",
@@ -201,15 +195,9 @@
                     "name": "mockDeviceAuto",
                     "displayName": "Mock Device (Auto created)",
                     "interfaces": ["system"],
-                    "basicTags": [
-                        "Device",
-                        "Actuator",
-                        "Gateway"
-                    ],
                     "createMethods": ["auto"],
                     "primaryActionTypeId": "defd3ed6-1a0d-400b-8879-a0202cf39935",
                     "primaryStateTypeId": "80baec19-54de-4948-ac46-31eabfaceb83",
-                    "deviceIcon": "Tune",
                     "paramTypes": [
                         {
                             "id": "d4f06047-125e-4479-9810-b54c189917f5",
@@ -321,14 +309,8 @@
                     "name": "mockPushButton",
                     "displayName": "Mock Device (Push Button)",
                     "interfaces": ["system"],
-                    "basicTags": [
-                        "Device",
-                        "Actuator",
-                        "Gateway"
-                    ],
                     "createMethods": ["discovery"],
                     "setupMethod": "pushButton",
-                    "deviceIcon": "Tune",
                     "pairingInfo": "Wait 3 second before you continue, the push button will be pressed automatically.",
                     "paramTypes": [ ],
                     "discoveryParamTypes": [
@@ -419,13 +401,7 @@
                     "id": "296f1fd4-e893-46b2-8a42-50d1bceb8730",
                     "name": "mockDisplayPin",
                     "displayName": "Mock Device (Display Pin)",
-                    "deviceIcon": "Tune",
                     "interfaces": ["system"],
-                    "basicTags": [
-                        "Device",
-                        "Actuator",
-                        "Gateway"
-                    ],
                     "createMethods": ["discovery"],
                     "setupMethod": "displayPin",
                     "pairingInfo": "Please enter the secret which normaly will be displayed on the device. For the mockdevice the pin is 243681.",
@@ -528,13 +504,7 @@
                     "id": "a71fbde9-9a38-4bf8-beab-c8aade2608ba",
                     "name": "mockParent",
                     "displayName": "Mock Device (Parent)",
-                    "deviceIcon": "Tune",
                     "interfaces": ["system"],
-                    "basicTags": [
-                        "Device",
-                        "Actuator",
-                        "Gateway"
-                    ],
                     "createMethods": ["user"],
                     "paramTypes": [ ],
                     "stateTypes": [
@@ -556,10 +526,6 @@
                     "displayName": "Mock Device (Child)",
                     "createMethods": ["auto"],
                     "paramTypes": [],
-                    "basicTags": [
-                        "Device",
-                        "Actuator"
-                    ],
                     "stateTypes": [
                         {
                             "id": "d24ede5f-4064-4898-bb84-cfb533b1fbc0",
@@ -577,10 +543,6 @@
                     "id": "515ffdf1-55e5-498d-9abc-4e2fe768f3a9",
                     "name": "mockInputType",
                     "displayName": "Mock Device (InputTypes)",
-                    "deviceIcon": "Tune",
-                    "basicTags": [
-                        "Device"
-                    ],
                     "createMethods": ["user"],
                     "paramTypes": [
                         {

--- a/plugins/mock/devicepluginmock.json
+++ b/plugins/mock/devicepluginmock.json
@@ -32,8 +32,6 @@
                     "displayName": "Mock Device",
                     "interfaces": ["system", "light", "gateway", "battery"],
                     "createMethods": ["user", "discovery"],
-                    "primaryActionTypeId": "defd3ed6-1a0d-400b-8879-a0202cf39935",
-                    "primaryStateTypeId": "80baec19-54de-4948-ac46-31eabfaceb83",
                     "discoveryParamTypes": [
                         {
                             "id": "d222adb4-2f9c-4c3f-8655-76400d0fb6ce",
@@ -196,8 +194,6 @@
                     "displayName": "Mock Device (Auto created)",
                     "interfaces": ["system"],
                     "createMethods": ["auto"],
-                    "primaryActionTypeId": "defd3ed6-1a0d-400b-8879-a0202cf39935",
-                    "primaryStateTypeId": "80baec19-54de-4948-ac46-31eabfaceb83",
                     "paramTypes": [
                         {
                             "id": "d4f06047-125e-4479-9810-b54c189917f5",

--- a/tests/auto/api.json
+++ b/tests/auto/api.json
@@ -1,4 +1,4 @@
-1.15
+2.0
 {
     "methods": {
         "Actions.ExecuteAction": {
@@ -1164,26 +1164,6 @@
                 "$ref:ParamType"
             ]
         },
-        "BasicTag": [
-            "BasicTagService",
-            "BasicTagDevice",
-            "BasicTagSensor",
-            "BasicTagActuator",
-            "BasicTagLighting",
-            "BasicTagEnergy",
-            "BasicTagMultimedia",
-            "BasicTagWeather",
-            "BasicTagGateway",
-            "BasicTagHeating",
-            "BasicTagCooling",
-            "BasicTagNotification",
-            "BasicTagSecurity",
-            "BasicTagTime",
-            "BasicTagShading",
-            "BasicTagAppliance",
-            "BasicTagCamera",
-            "BasicTagLock"
-        ],
         "BasicType": [
             "Uuid",
             "String",
@@ -1244,13 +1224,9 @@
             "actionTypes": [
                 "$ref:ActionType"
             ],
-            "basicTags": [
-                "$ref:BasicTag"
-            ],
             "createMethods": [
                 "$ref:CreateMethod"
             ],
-            "deviceIcon": "$ref:DeviceIcon",
             "discoveryParamTypes": [
                 "$ref:ParamType"
             ],
@@ -1263,9 +1239,6 @@
                 "String"
             ],
             "name": "String",
-            "o:criticalStateTypeId": "Uuid",
-            "o:primaryActionTypeId": "Uuid",
-            "o:primaryStateTypeId": "Uuid",
             "paramTypes": [
                 "$ref:ParamType"
             ],
@@ -1311,44 +1284,6 @@
             "DeviceErrorPairingTransactionIdNotFound",
             "DeviceErrorParameterNotWritable"
         ],
-        "DeviceIcon": [
-            "DeviceIconNone",
-            "DeviceIconBed",
-            "DeviceIconBlinds",
-            "DeviceIconCeilingLamp",
-            "DeviceIconCouch",
-            "DeviceIconDeskLamp",
-            "DeviceIconDesk",
-            "DeviceIconHifi",
-            "DeviceIconPower",
-            "DeviceIconEnergy",
-            "DeviceIconRadio",
-            "DeviceIconSmartPhone",
-            "DeviceIconSocket",
-            "DeviceIconStandardLamp",
-            "DeviceIconSun",
-            "DeviceIconTablet",
-            "DeviceIconThermometer",
-            "DeviceIconTune",
-            "DeviceIconTv",
-            "DeviceIconBattery",
-            "DeviceIconDishwasher",
-            "DeviceIconWashingMachine",
-            "DeviceIconLaundryDryer",
-            "DeviceIconIrHeater",
-            "DeviceIconRadiator",
-            "DeviceIconSwitch",
-            "DeviceIconMotionDetectors",
-            "DeviceIconWeather",
-            "DeviceIconTime",
-            "DeviceIconLightBulb",
-            "DeviceIconGateway",
-            "DeviceIconMail",
-            "DeviceIconNetwork",
-            "DeviceIconCloud",
-            "DeviceIconGarage",
-            "DeviceIconRollerShutter"
-        ],
         "Event": {
             "deviceId": "Uuid",
             "eventTypeId": "Uuid",
@@ -1370,8 +1305,6 @@
             "id": "Uuid",
             "index": "Int",
             "name": "String",
-            "o:graphRelevant": "Bool",
-            "o:ruleRelevant": "Bool",
             "paramTypes": [
                 "$ref:ParamType"
             ]
@@ -1628,13 +1561,11 @@
             "id": "Uuid",
             "index": "Int",
             "name": "String",
-            "o:graphRelevant": "Bool",
             "o:maxValue": "Variant",
             "o:minValue": "Variant",
             "o:possibleValues": [
                 "Variant"
             ],
-            "o:ruleRelevant": "Bool",
             "o:unit": "$ref:Unit",
             "type": "$ref:BasicType"
         },


### PR DESCRIPTION
Removes:
* basicTags
* deviceIcon
* primaryStateTypeId
* criticalStateTypeId
* primaryActionTypeId
* ruleRelevant
* eventRuleRelevant
* graphRelevant