### PR TITLE
Remove build artefacts from gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,16 +13,6 @@ doc/interfacelist.qdoc
 debs*.tar
 
 # in source build artifaces
-*.o
-moc_*.cpp
-*.moc
-Makefile
-*.so*
-qrc_*.cpp
-*debhelper.log
-*.dirs
-*.install
-*.substvars
 tests/auto/actions/testactions
 tests/auto/configurations/testconfigurations
 tests/auto/devices/testdevices
@@ -43,19 +33,5 @@ tests/auto/timemanager/testtimemanager
 tests/auto/versioning/testversioning
 tests/auto/webserver/webserver
 tests/auto/websocketserver/websocketserver
-
-# debian package generated stuff
-debian/.debhelper/
-debian/debhelper-build-stamp
-debian/files
-debian/guh-dbg/
-debian/guh-tests/
-debian/guh-translations/
-debian/guh/
-debian/guhd/
-debian/libguh1-dev/
-debian/libguh1/
-debian/tmp/
-server/guhd
 
 .idea/


### PR DESCRIPTION
Reasoning: Basically one should never have build artefacts in the source
directory anyways as out-of-source builds are the recommended way of
working anyways. If, for some reason that's still happening (e.g. with
crossbuilder) then this helps a lot to clean the source dir again after
building. "crossbuilder clean" only works with the build container
ready, if the computer has been rebooted or build containers have
been deleted in the meantime, it becomes virtually impossible to
clean up the source dir again if git doesn't help any more.